### PR TITLE
Add LangGraph best practice example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ calling capability and stores conversation history in
 
 It also exposes `answer_about_course`, a RAG powered tool that retrieves
 course information from a Qdrant vector store before crafting the reply.
+
+## Basic chatbot graph
+
+`features/chatbot/workflow/basic_chatbot_graph.py` implements the
+[LangGraph best practice](https://langchain-ai.github.io/langgraph/tutorials/get-started/1-build-basic-chatbot/)
+for building a minimal stateful chatbot. It defines a graph with a single
+`chatbot` node and uses `add_messages` to append responses to the state.

--- a/features/chatbot/workflow/basic_chatbot_graph.py
+++ b/features/chatbot/workflow/basic_chatbot_graph.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Annotated
+from typing_extensions import TypedDict
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langchain_groq import ChatGroq
+
+
+class GraphState(TypedDict):
+    """State tracked by the basic chatbot graph."""
+
+    messages: Annotated[list, add_messages]
+
+
+graph_builder = StateGraph(GraphState)
+
+llm = ChatGroq(model_name="llama3-8b-8192", temperature=0)
+
+
+def chatbot(state: GraphState) -> dict:
+    """Simple chatbot node returning the model response."""
+    return {"messages": [llm.invoke(state["messages"])]}
+
+
+graph_builder.add_node("chatbot", chatbot)
+
+# Entry and exit points
+graph_builder.add_edge(START, "chatbot")
+graph_builder.add_edge("chatbot", END)
+
+workflow = graph_builder.compile()

--- a/features/chatbot/workflow/function_graph.py
+++ b/features/chatbot/workflow/function_graph.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import operator
 from typing import List, TypedDict, Annotated
 
 from langgraph.graph import StateGraph, END
+from langgraph.graph.message import add_messages
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langchain_groq import ChatGroq
 from langchain.agents import AgentExecutor, create_openai_functions_agent
@@ -19,7 +19,7 @@ from features.user_management.tools.user_tools import UserTools
 class GraphState(TypedDict):
     """State tracked by the tool calling graph."""
 
-    messages: Annotated[List[HumanMessage], operator.add]
+    messages: Annotated[List[HumanMessage], add_messages]
     results: List[str]
     error: str | None
 

--- a/features/cours_management/workflow/cours_graph.py
+++ b/features/cours_management/workflow/cours_graph.py
@@ -1,9 +1,10 @@
 # features/cours_management/workflow/cours_graph.py
 # ──────────────────────────────────────────────────────────────────────────────
-import io, logging, operator
+import io, logging
 from typing import TypedDict, Annotated, List, Optional
 
 from langgraph.graph          import StateGraph, END
+from langgraph.graph.message  import add_messages
 from langchain_core.messages  import HumanMessage, SystemMessage
 from PyPDF2                   import PdfReader
 
@@ -26,7 +27,7 @@ from features.cours_management.memory_course.agent_memory import AgentMemory
 
 # 1. État ─────────────────────────────────────────────────────────────────────
 class GraphState(TypedDict):
-    messages           : Annotated[List[HumanMessage], operator.add]
+    messages           : Annotated[List[HumanMessage], add_messages]
     detected_operations: List[dict]
     pending_operations : List[dict]
     results            : List[dict]

--- a/features/user_management/test.py
+++ b/features/user_management/test.py
@@ -2,12 +2,12 @@
 
 import json
 import logging
-import operator
 from typing import TypedDict, Annotated, List, Optional
 from features.cours_management.agents.rag_agent import RAGAgent
 import os
 from langchain_core.messages import HumanMessage
 from langgraph.graph import StateGraph, END
+from langgraph.graph.message import add_messages
 from features.cours_management.memory_course.conversation_memory import ConversationMemory
 
 from features.cours_management.agents.SuggestionAgent import SuggestionAgent
@@ -22,7 +22,7 @@ from features.cours_management.agents.OperationDetectionAgent import OperationDe
 
 # --- Typage de l'état du graphe ---
 class GraphState(TypedDict):
-    messages: Annotated[List[HumanMessage], operator.add]
+    messages: Annotated[List[HumanMessage], add_messages]
     detected_operations: List[dict]
     pending_operations: List[dict]
     results: List[dict]


### PR DESCRIPTION
## Summary
- add a `basic_chatbot_graph` example following LangGraph best practices
- document the new workflow in the README
- switch existing graphs to use `add_messages`

## Testing
- `python -m py_compile features/chatbot/workflow/basic_chatbot_graph.py`
- `python -m py_compile features/chatbot/workflow/function_graph.py features/cours_management/workflow/cours_graph.py features/user_management/test.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_core')*

------
https://chatgpt.com/codex/tasks/task_e_686546ef971483238e8a9c7edb8240ed